### PR TITLE
web: Persist radar config per device

### DIFF
--- a/web/lib/radar/radar_config.ex
+++ b/web/lib/radar/radar_config.ex
@@ -3,7 +3,10 @@ defmodule Radar.RadarConfig do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @device_types ~w(rd03d ld2451)
+
   schema "radar_configs" do
+    field :device_type, :string
     field :authorized_speed, :integer, default: 25
     field :min_dist, :integer, default: 0
     field :max_dist, :integer, default: 10_000
@@ -14,9 +17,12 @@ defmodule Radar.RadarConfig do
     timestamps()
   end
 
+  def supported_device_types, do: @device_types
+
   def changeset(config, attrs) do
     config
     |> cast(attrs, [
+      :device_type,
       :authorized_speed,
       :min_dist,
       :max_dist,
@@ -25,6 +31,7 @@ defmodule Radar.RadarConfig do
       :capture_paused
     ])
     |> validate_required([
+      :device_type,
       :authorized_speed,
       :min_dist,
       :max_dist,
@@ -32,12 +39,14 @@ defmodule Radar.RadarConfig do
       :aperture_angle,
       :capture_paused
     ])
+    |> validate_inclusion(:device_type, @device_types)
     |> validate_number(:authorized_speed, greater_than: 0)
     |> validate_number(:min_dist, greater_than_or_equal_to: 0)
     |> validate_number(:max_dist, greater_than: 0)
     |> validate_number(:trigger_cooldown, greater_than_or_equal_to: 0)
     |> validate_number(:aperture_angle, greater_than: 0, less_than_or_equal_to: 180)
     |> validate_distance_order()
+    |> unique_constraint(:device_type)
   end
 
   defp validate_distance_order(changeset) do

--- a/web/lib/radar/radar_configs.ex
+++ b/web/lib/radar/radar_configs.ex
@@ -6,13 +6,19 @@ defmodule Radar.RadarConfigs do
   alias Radar.Repo
   alias Radar.RadarConfig
 
-  def get_config! do
-    Repo.one!(RadarConfig)
+  def supported_device_types, do: RadarConfig.supported_device_types()
+
+  def get_config!(device_type) do
+    device_type = validate_device_type!(device_type)
+
+    Repo.get_by!(RadarConfig, device_type: device_type)
   end
 
-  def update_config(params) do
-    get_config!()
-    |> RadarConfig.changeset(params)
+  def update_config(device_type, params) do
+    device_type = validate_device_type!(device_type)
+
+    get_config!(device_type)
+    |> RadarConfig.changeset(discard_device_type(params))
     |> Repo.update()
     |> case do
       {:ok, config} ->
@@ -24,8 +30,20 @@ defmodule Radar.RadarConfigs do
     end
   end
 
-  def config_payload(%RadarConfig{} = config) do
+  def config_payload(device_type) when is_binary(device_type) do
+    config_payload(device_type, get_config!(device_type))
+  end
+
+  def config_payload(device_type, %RadarConfig{} = config) do
+    device_type = validate_device_type!(device_type)
+
+    if config.device_type != device_type do
+      raise ArgumentError,
+            "expected #{device_type} radar config, got #{inspect(config.device_type)}"
+    end
+
     %{
+      device_type: config.device_type,
       authorized_speed: config.authorized_speed,
       min_dist: config.min_dist,
       max_dist: config.max_dist,
@@ -33,5 +51,20 @@ defmodule Radar.RadarConfigs do
       aperture_angle: config.aperture_angle,
       capture_paused: config.capture_paused
     }
+  end
+
+  defp discard_device_type(params) when is_map(params) do
+    Map.drop(params, [:device_type, "device_type"])
+  end
+
+  defp discard_device_type(params), do: params
+
+  defp validate_device_type!(device_type) do
+    if device_type in supported_device_types() do
+      device_type
+    else
+      raise ArgumentError,
+            "unsupported radar device_type #{inspect(device_type)}; expected one of: #{Enum.join(supported_device_types(), ", ")}"
+    end
   end
 end

--- a/web/lib/radar_web/channels/radar_config_channel.ex
+++ b/web/lib/radar_web/channels/radar_config_channel.ex
@@ -8,6 +8,8 @@ defmodule RadarWeb.RadarConfigChannel do
   alias Radar.RadarConfigs
 
   @uploader_debug_topic "uploader_debug"
+  @device_type "rd03d"
+
   @impl true
   def join("radar:config", _payload, socket) do
     case RadarWeb.Presence.track_uploader(self()) do
@@ -21,8 +23,8 @@ defmodule RadarWeb.RadarConfigChannel do
 
   @impl true
   def handle_in("get_config", _payload, socket) do
-    config = RadarConfigs.get_config!()
-    {:reply, {:ok, RadarConfigs.config_payload(config)}, socket}
+    config = RadarConfigs.get_config!(@device_type)
+    {:reply, {:ok, RadarConfigs.config_payload(@device_type, config)}, socket}
   end
 
   @impl true
@@ -52,10 +54,12 @@ defmodule RadarWeb.RadarConfigChannel do
   end
 
   @impl true
-  def handle_info({:config_updated, config}, socket) do
-    push(socket, "config_updated", RadarConfigs.config_payload(config))
+  def handle_info({:config_updated, %{device_type: @device_type} = config}, socket) do
+    push(socket, "config_updated", RadarConfigs.config_payload(@device_type, config))
     {:noreply, socket}
   end
+
+  def handle_info({:config_updated, _config}, socket), do: {:noreply, socket}
 
   defp uploader_log_message(%{"message" => message}), do: message
   defp uploader_log_message(%{"line" => message}), do: message

--- a/web/lib/radar_web/controllers/api/photo_controller.ex
+++ b/web/lib/radar_web/controllers/api/photo_controller.ex
@@ -5,6 +5,8 @@ defmodule RadarWeb.Api.PhotoController do
 
   alias Radar.{Infractions, Photos, RadarConfigs}
 
+  @device_type "rd03d"
+
   def create(conn, params) do
     case authenticate_api_key(conn) do
       {:ok, _key} ->
@@ -66,7 +68,7 @@ defmodule RadarWeb.Api.PhotoController do
   end
 
   defp ensure_capture_active do
-    if RadarConfigs.get_config!().capture_paused do
+    if RadarConfigs.get_config!(@device_type).capture_paused do
       {:error, "Radar capture is paused"}
     else
       :ok

--- a/web/lib/radar_web/live/admin_radar_config_live.ex
+++ b/web/lib/radar_web/live/admin_radar_config_live.ex
@@ -9,6 +9,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
   @max_uploader_logs 100
   @uploader_debug_topic "uploader_debug"
+  @device_type "rd03d"
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
@@ -19,11 +20,12 @@ defmodule RadarWeb.AdminRadarConfigLive do
       Phoenix.PubSub.subscribe(Radar.PubSub, Presence.uploader_topic())
     end
 
-    config = RadarConfigs.get_config!()
+    config = RadarConfigs.get_config!(@device_type)
     last_target = last_known_target()
 
     socket =
       socket
+      |> assign(:device_type, @device_type)
       |> assign(:config, config)
       |> assign(:form, config_to_form(config))
       |> assign(:infraction_count, Infractions.count_infractions())
@@ -122,7 +124,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
               id="radar-canvas"
               phx-hook=".RadarCanvas"
               phx-update="ignore"
-              data-radar-config={Jason.encode!(RadarConfigs.config_payload(@config))}
+              data-radar-config={Jason.encode!(RadarConfigs.config_payload(@device_type, @config))}
               width="600"
               height="400"
               class="w-full rounded-lg"
@@ -353,7 +355,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
   def handle_event("update_config", %{"config" => params}, socket) do
     db_params = form_params_to_db(params)
 
-    case RadarConfigs.update_config(db_params) do
+    case RadarConfigs.update_config(@device_type, db_params) do
       {:ok, config} ->
         {:noreply,
          socket
@@ -367,7 +369,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   def handle_event("toggle_capture", _params, socket) do
-    case RadarConfigs.update_config(%{capture_paused: !socket.assigns.config.capture_paused}) do
+    case RadarConfigs.update_config(@device_type, %{
+           capture_paused: !socket.assigns.config.capture_paused
+         }) do
       {:ok, config} ->
         {:noreply,
          socket
@@ -380,13 +384,15 @@ defmodule RadarWeb.AdminRadarConfigLive do
     end
   end
 
-  def handle_info({:config_updated, config}, socket) do
+  def handle_info({:config_updated, %{device_type: @device_type} = config}, socket) do
     {:noreply,
      socket
      |> assign(:config, config)
      |> assign(:form, config_to_form(config))
      |> push_config_event(config)}
   end
+
+  def handle_info({:config_updated, _config}, socket), do: {:noreply, socket}
 
   def handle_info({:new_infraction, _infraction}, socket) do
     {:noreply, assign(socket, :infraction_count, Infractions.count_infractions())}
@@ -635,7 +641,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   defp push_config_event(socket, config) do
-    push_event(socket, "radar_config", RadarConfigs.config_payload(config))
+    push_event(socket, "radar_config", RadarConfigs.config_payload(@device_type, config))
   end
 
   defp parse_float(val) when is_binary(val) do

--- a/web/priv/repo/migrations/20260628000000_add_device_type_to_radar_configs.exs
+++ b/web/priv/repo/migrations/20260628000000_add_device_type_to_radar_configs.exs
@@ -1,0 +1,54 @@
+defmodule Radar.Repo.Migrations.AddDeviceTypeToRadarConfigs do
+  use Ecto.Migration
+
+  def up do
+    alter table(:radar_configs) do
+      add :device_type, :string, null: false, default: "rd03d"
+    end
+
+    execute """
+    UPDATE radar_configs
+    SET device_type = 'rd03d'
+    WHERE device_type IS NULL OR device_type = ''
+    """
+
+    execute """
+    INSERT INTO radar_configs (
+      device_type,
+      authorized_speed,
+      min_dist,
+      max_dist,
+      trigger_cooldown,
+      aperture_angle,
+      capture_paused,
+      inserted_at,
+      updated_at
+    )
+    SELECT
+      'ld2451',
+      25,
+      0,
+      10000,
+      1000,
+      90,
+      0,
+      datetime('now'),
+      datetime('now')
+    WHERE NOT EXISTS (
+      SELECT 1 FROM radar_configs WHERE device_type = 'ld2451'
+    )
+    """
+
+    create unique_index(:radar_configs, [:device_type])
+  end
+
+  def down do
+    drop unique_index(:radar_configs, [:device_type])
+
+    execute "DELETE FROM radar_configs WHERE device_type = 'ld2451'"
+
+    alter table(:radar_configs) do
+      remove :device_type
+    end
+  end
+end

--- a/web/test/radar/radar_configs_test.exs
+++ b/web/test/radar/radar_configs_test.exs
@@ -1,18 +1,60 @@
 defmodule Radar.RadarConfigsTest do
   use Radar.DataCase
 
+  alias Radar.RadarConfig
   alias Radar.RadarConfigs
 
-  test "config payload includes uploader capture state" do
-    config = RadarConfigs.get_config!()
+  @rd03d "rd03d"
+  @ld2451 "ld2451"
 
-    assert RadarConfigs.config_payload(config).aperture_angle == 90
-    assert RadarConfigs.config_payload(config).capture_paused == false
+  test "migrated configs exist for each supported radar device" do
+    assert RadarConfigs.supported_device_types() == [@rd03d, @ld2451]
+
+    rd03d_config = RadarConfigs.get_config!(@rd03d)
+    ld2451_config = RadarConfigs.get_config!(@ld2451)
+
+    assert rd03d_config.device_type == @rd03d
+    assert ld2451_config.device_type == @ld2451
+    assert ld2451_config.authorized_speed == 25
+    assert ld2451_config.min_dist == 0
+    assert ld2451_config.max_dist == 10_000
+    assert ld2451_config.trigger_cooldown == 1000
+    assert ld2451_config.aperture_angle == 90
+    assert ld2451_config.capture_paused == false
   end
 
-  test "update_config persists aperture angle" do
+  test "changeset requires a supported device type" do
+    changeset =
+      RadarConfig.changeset(%RadarConfig{}, %{
+        device_type: "fake",
+        authorized_speed: 50,
+        min_dist: 500,
+        max_dist: 12_000,
+        trigger_cooldown: 1500,
+        aperture_angle: 75,
+        capture_paused: false
+      })
+
+    assert "is invalid" in errors_on(changeset).device_type
+  end
+
+  test "get_config! requires an explicit supported device type" do
+    assert_raise ArgumentError, ~r/unsupported radar device_type/, fn ->
+      RadarConfigs.get_config!("fake")
+    end
+  end
+
+  test "config payload includes device type and uploader capture state" do
+    config = RadarConfigs.get_config!(@rd03d)
+
+    assert RadarConfigs.config_payload(@rd03d, config).device_type == @rd03d
+    assert RadarConfigs.config_payload(@rd03d, config).aperture_angle == 90
+    assert RadarConfigs.config_payload(@rd03d, config).capture_paused == false
+  end
+
+  test "update_config persists aperture angle for the requested device" do
     assert {:ok, config} =
-             RadarConfigs.update_config(%{
+             RadarConfigs.update_config(@ld2451, %{
                authorized_speed: 50,
                min_dist: 500,
                max_dist: 12_000,
@@ -20,20 +62,22 @@ defmodule Radar.RadarConfigsTest do
                aperture_angle: 75
              })
 
+    assert config.device_type == @ld2451
     assert config.aperture_angle == 75
-    assert RadarConfigs.config_payload(config).aperture_angle == 75
+    assert RadarConfigs.config_payload(@ld2451, config).aperture_angle == 75
+    assert RadarConfigs.get_config!(@rd03d).aperture_angle == 90
   end
 
   test "update_config persists capture pause state" do
-    assert {:ok, config} = RadarConfigs.update_config(%{capture_paused: true})
+    assert {:ok, config} = RadarConfigs.update_config(@rd03d, %{capture_paused: true})
 
     assert config.capture_paused == true
-    assert RadarConfigs.config_payload(config).capture_paused == true
+    assert RadarConfigs.config_payload(@rd03d, config).capture_paused == true
   end
 
   test "update_config rejects max distance below min distance" do
     assert {:error, changeset} =
-             RadarConfigs.update_config(%{
+             RadarConfigs.update_config(@rd03d, %{
                authorized_speed: 50,
                min_dist: 5000,
                max_dist: 4000,

--- a/web/test/radar_web/channels/radar_config_channel_test.exs
+++ b/web/test/radar_web/channels/radar_config_channel_test.exs
@@ -6,6 +6,7 @@ defmodule RadarWeb.RadarConfigChannelTest do
   alias RadarWeb.Presence
 
   @uploader_debug_topic "uploader_debug"
+  @device_type "rd03d"
 
   setup do
     Radar.RadarData.clear()
@@ -27,7 +28,7 @@ defmodule RadarWeb.RadarConfigChannelTest do
              Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
              |> subscribe_and_join(RadarConfigChannel, "radar:config")
 
-    assert {:ok, _config} = RadarConfigs.update_config(%{capture_paused: true})
+    assert {:ok, _config} = RadarConfigs.update_config(@device_type, %{capture_paused: true})
 
     assert_push "config_updated", %{capture_paused: true}
   end
@@ -47,7 +48,7 @@ defmodule RadarWeb.RadarConfigChannelTest do
              Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
              |> subscribe_and_join(RadarConfigChannel, "radar:config")
 
-    assert {:ok, _config} = RadarConfigs.update_config(%{capture_paused: true})
+    assert {:ok, _config} = RadarConfigs.update_config(@device_type, %{capture_paused: true})
     Phoenix.PubSub.subscribe(Radar.PubSub, "radar_data")
 
     push(socket, "target_data", %{"x" => 1, "y" => 2})

--- a/web/test/radar_web/controllers/api/photo_controller_test.exs
+++ b/web/test/radar_web/controllers/api/photo_controller_test.exs
@@ -7,6 +7,7 @@ defmodule RadarWeb.Api.PhotoControllerTest do
 
   @valid_api_key "radar-dev-key"
   @invalid_api_key "invalid-key"
+  @device_type "rd03d"
 
   @valid_infraction_data %{
     "datetime_taken" => "2024-01-15T14:30:00",
@@ -153,7 +154,7 @@ defmodule RadarWeb.Api.PhotoControllerTest do
     end
 
     test "rejects photo uploads while capture is paused", %{conn: conn, upload: upload} do
-      assert {:ok, _config} = RadarConfigs.update_config(%{capture_paused: true})
+      assert {:ok, _config} = RadarConfigs.update_config(@device_type, %{capture_paused: true})
 
       conn =
         conn

--- a/web/test/radar_web/live/admin_live_test.exs
+++ b/web/test/radar_web/live/admin_live_test.exs
@@ -8,6 +8,7 @@ defmodule RadarWeb.AdminLiveTest do
   alias RadarWeb.Presence
 
   @uploader_debug_topic "uploader_debug"
+  @device_type "rd03d"
 
   setup do
     Repo.delete_all(Radar.Infraction)
@@ -140,7 +141,7 @@ defmodule RadarWeb.AdminLiveTest do
         |> Phoenix.LiveViewTest.render_change()
       end)
 
-    config = RadarConfigs.get_config!()
+    config = RadarConfigs.get_config!(@device_type)
 
     assert config.authorized_speed == 55
     assert config.min_dist == 6500
@@ -167,7 +168,7 @@ defmodule RadarWeb.AdminLiveTest do
       |> assert_has("p", "Camera capture is active.")
       |> assert_has("button[aria-pressed='false']", "Pause radar")
 
-    assert RadarConfigs.config_payload(RadarConfigs.get_config!()).capture_paused == false
+    assert RadarConfigs.config_payload(@device_type).capture_paused == false
 
     session =
       session
@@ -175,14 +176,14 @@ defmodule RadarWeb.AdminLiveTest do
       |> assert_has("p", "Camera capture is paused.")
       |> assert_has("button[aria-pressed='true']", "Resume radar")
 
-    assert RadarConfigs.config_payload(RadarConfigs.get_config!()).capture_paused == true
+    assert RadarConfigs.config_payload(@device_type).capture_paused == true
 
     session
     |> click_button("Resume radar")
     |> assert_has("p", "Camera capture is active.")
     |> assert_has("button[aria-pressed='false']", "Pause radar")
 
-    assert RadarConfigs.config_payload(RadarConfigs.get_config!()).capture_paused == false
+    assert RadarConfigs.config_payload(@device_type).capture_paused == false
   end
 
   test "lists infractions with individual photo links and a reliable page archive", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Add explicit per-device radar config rows keyed by device_type.
- Migrate existing config to rd03d and seed ld2451 defaults.
- Update RadarConfigs APIs and current callers to use explicit rd03d pending handshake/UI tasks.

## Verification
- cd web && mix test test/radar/radar_configs_test.exs
- cd web && mix test test/radar_web/channels/radar_config_channel_test.exs test/radar_web/controllers/api/photo_controller_test.exs test/radar_web/live/admin_live_test.exs

Beadwork: rc-edm.7