### PR TITLE
uploader: Add radar device handshake

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -11,7 +11,7 @@ This project has three runtime pieces:
 Deploy the uploader and ESP firmware to the Pi:
 
 ```sh
-./install.sh
+./install.sh --radar-device rd03d
 ```
 
 Defaults:
@@ -19,6 +19,7 @@ Defaults:
 - SSH host: `rshep.local`
 - ESP USB serial for flashing and firmware logs: `/dev/ttyACM0`
 - Pi-to-ESP config UART: `/dev/serial0`
+- Radar device: explicit `rd03d` or `ld2451` via `--radar-device`
 
 The install script always rebuilds the ESP firmware, flashes it before updating the uploader service, and restarts `radar-uploader.service`.
 
@@ -39,7 +40,7 @@ make deploy-all
 Use this when working on the admin UI without hardware:
 
 ```sh
-./start.sh --fake-people --local-web
+./start.sh --radar-device rd03d --fake-people --local-web
 ```
 
 This starts Phoenix locally and runs the uploader in `--test-mode` against `http://localhost:4000`.
@@ -49,7 +50,7 @@ This starts Phoenix locally and runs the uploader in `--test-mode` against `http
 Use this when debugging the real radar through the local admin page:
 
 ```sh
-./start.sh --local-web --remote-uploader rshep.local
+./start.sh --radar-device rd03d --local-web --remote-uploader rshep.local
 ```
 
 This starts Phoenix locally, detects this machine's LAN IPv4 address, stops the Pi's normal `radar-uploader.service`, and runs the installed Pi uploader over SSH against the local web server.
@@ -57,7 +58,7 @@ This starts Phoenix locally, detects this machine's LAN IPv4 address, stops the 
 If LAN IP detection is wrong, override it:
 
 ```sh
-LOCAL_API_ENDPOINT_LAN=http://192.168.1.65:4000 ./start.sh --local-web --remote-uploader rshep.local
+LOCAL_API_ENDPOINT_LAN=http://192.168.1.65:4000 ./start.sh --radar-device rd03d --local-web --remote-uploader rshep.local
 ```
 
 When the local `start.sh` process exits, it should restart the normal Pi service. If cleanup is interrupted, restore it manually:

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ ESPFLASH_BINARY="${ROOT_DIR}/.nix/espflash/${UPLOADER_TARGET}/bin/espflash"
 SERIAL_PORT="${SERIAL_PORT:-/dev/ttyACM0}"
 CONFIG_SERIAL_PORT="${CONFIG_SERIAL_PORT:-/dev/serial0}"
 RADAR_BINARY="${RADAR_BINARY:-${ROOT_DIR}/radar/target/xtensa-esp32s3-none-elf/debug/radar-a-chepers}"
+RADAR_DEVICE="${RADAR_DEVICE:-}"
 
 REMOTE="${REMOTE:-rshep.local}"
 REMOTE_FROM_CLI=0
@@ -55,6 +56,8 @@ Options:
   --serial-port PATH          ESP USB serial device for flashing/logs. Default: ${SERIAL_PORT}
   --config-serial-port PATH   Pi UART device used to send config to ESP.
                               Default: ${CONFIG_SERIAL_PORT}
+  --radar-device DEVICE       Active radar device for this uploader connection: rd03d or ld2451.
+                              RADAR_DEVICE can also provide this value.
   --radar-binary PATH         Local radar firmware ELF to copy.
                               Default: ${RADAR_BINARY}
   --remote-app-dir PATH       Remote install directory. Default: ${REMOTE_APP_DIR}
@@ -109,6 +112,23 @@ target_env_name() {
   local target="$1"
   target="${target//-/_}"
   printf '%s\n' "${target^^}"
+}
+
+validate_radar_device() {
+  if [ -z "$RADAR_DEVICE" ]; then
+    echo "error: --radar-device is required (rd03d or ld2451)" >&2
+    exit 1
+  fi
+
+  case "$RADAR_DEVICE" in
+    rd03d | ld2451)
+      ;;
+    *)
+      echo "error: unsupported radar device: ${RADAR_DEVICE}" >&2
+      echo "       expected one of: rd03d, ld2451" >&2
+      exit 1
+      ;;
+  esac
 }
 
 run_cargo() {
@@ -230,6 +250,7 @@ write_env_file() {
     printf 'INFRACTIONS_DIR=%s\n' "$REMOTE_INFRACTIONS_DIR"
     printf 'SERIAL_PORT=%s\n' "$SERIAL_PORT"
     printf 'CONFIG_SERIAL_PORT=%s\n' "$CONFIG_SERIAL_PORT"
+    printf 'RADAR_DEVICE=%s\n' "$RADAR_DEVICE"
     printf 'ELF_PATH=%s\n' "$REMOTE_RADAR_BINARY"
     printf 'RUST_LOG=%s\n' "$RUST_LOG"
   } >"$env_file"
@@ -247,7 +268,7 @@ After=network-online.target
 [Service]
 Environment=RUST_LOG=${RUST_LOG}
 WorkingDirectory=${REMOTE_APP_DIR}
-ExecStart=${REMOTE_APP_DIR}/uploader --api-endpoint ${API_ENDPOINT} --api-key ${API_KEY} --infractions-dir ${REMOTE_INFRACTIONS_DIR} --serial-port ${SERIAL_PORT} --config-serial-port ${CONFIG_SERIAL_PORT} --elf-path ${REMOTE_RADAR_BINARY}
+ExecStart=${REMOTE_APP_DIR}/uploader --api-endpoint ${API_ENDPOINT} --api-key ${API_KEY} --infractions-dir ${REMOTE_INFRACTIONS_DIR} --radar-device ${RADAR_DEVICE} --serial-port ${SERIAL_PORT} --config-serial-port ${CONFIG_SERIAL_PORT} --elf-path ${REMOTE_RADAR_BINARY}
 Restart=always
 RestartSec=5
 
@@ -329,6 +350,11 @@ while [ "$#" -gt 0 ]; do
       CONFIG_SERIAL_PORT="$2"
       shift
       ;;
+    --radar-device)
+      require_option_value "$1" "${2:-}"
+      RADAR_DEVICE="$2"
+      shift
+      ;;
     --radar-binary)
       require_option_value "$1" "${2:-}"
       RADAR_BINARY="$2"
@@ -389,6 +415,8 @@ while [ "$#" -gt 0 ]; do
 
   shift
 done
+
+validate_radar_device
 
 LOCAL_TMP_DIR="$(mktemp -d)"
 

--- a/start.sh
+++ b/start.sh
@@ -15,6 +15,7 @@ LOCAL_API_ENDPOINT="${LOCAL_API_ENDPOINT%/}"
 SERIAL_PORT="${SERIAL_PORT:-/dev/ttyACM0}"
 CONFIG_SERIAL_PORT="${CONFIG_SERIAL_PORT:-/dev/serial0}"
 RADAR_BINARY="${RADAR_BINARY:-${ROOT_DIR}/radar/target/xtensa-esp32s3-none-elf/debug/radar-a-chepers}"
+RADAR_DEVICE="${RADAR_DEVICE:-}"
 
 SSH_BIN="${SSH_BIN:-ssh}"
 REMOTE_UPLOADER_HOST="${REMOTE_UPLOADER_HOST:-}"
@@ -33,7 +34,7 @@ REMOTE_UPLOADER_STARTED=0
 
 usage() {
   cat <<EOF
-Usage: ./start.sh [--fake-people] [--local-web] [--remote-uploader HOST]
+Usage: ./start.sh --radar-device DEVICE [--fake-people] [--local-web] [--remote-uploader HOST]
 
 By default, starts the uploader in live hardware mode connected to ${FLY_APP_URL}.
 
@@ -42,7 +43,9 @@ Options:
   --local-web             Start the Phoenix web server locally and connect the uploader to it.
   --remote-uploader HOST  With --local-web, run the installed Pi uploader over SSH and
                           point it at this machine's LAN URL.
+  --radar-device DEVICE   Active radar device for this uploader connection: rd03d or ld2451.
   SERIAL_PORT and CONFIG_SERIAL_PORT override the live hardware serial devices.
+  RADAR_DEVICE can also provide --radar-device.
   LOCAL_API_ENDPOINT_LAN overrides the URL given to the remote Pi.
   -h, --help              Show this help.
 EOF
@@ -60,6 +63,23 @@ require_option_value() {
     echo "error: ${option} requires a value" >&2
     exit 1
   fi
+}
+
+validate_radar_device() {
+  if [ -z "$RADAR_DEVICE" ]; then
+    echo "error: --radar-device is required (rd03d or ld2451)" >&2
+    exit 1
+  fi
+
+  case "$RADAR_DEVICE" in
+    rd03d | ld2451)
+      ;;
+    *)
+      echo "error: unsupported radar device: ${RADAR_DEVICE}" >&2
+      echo "       expected one of: rd03d, ld2451" >&2
+      exit 1
+      ;;
+  esac
 }
 
 cleanup() {
@@ -244,6 +264,7 @@ start_uploader() {
     --api-endpoint "$api_endpoint"
     --api-key "$api_key"
     --infractions-dir "$infractions_dir"
+    --radar-device "$RADAR_DEVICE"
   )
 
   if [ "$FAKE_PEOPLE" = 1 ]; then
@@ -282,6 +303,7 @@ start_remote_uploader() {
     printf '%s %s ' "--api-endpoint" "$(shell_quote "$api_endpoint")"
     printf '%s %s ' "--api-key" "$(shell_quote "$api_key")"
     printf '%s %s ' "--infractions-dir" "$(shell_quote "$REMOTE_INFRACTIONS_DIR")"
+    printf '%s %s ' "--radar-device" "$(shell_quote "$RADAR_DEVICE")"
     printf '%s %s ' "--serial-port" "$(shell_quote "$SERIAL_PORT")"
     printf '%s %s ' "--config-serial-port" "$(shell_quote "$CONFIG_SERIAL_PORT")"
     printf '%s %s' "--elf-path" "$(shell_quote "$REMOTE_RADAR_BINARY")"
@@ -304,6 +326,11 @@ while [ "$#" -gt 0 ]; do
     --remote-uploader)
       require_option_value "$1" "${2:-}"
       REMOTE_UPLOADER_HOST="$2"
+      shift
+      ;;
+    --radar-device)
+      require_option_value "$1" "${2:-}"
+      RADAR_DEVICE="$2"
       shift
       ;;
     -h | --help)
@@ -343,6 +370,8 @@ if [ "$START_WEB_ONLY" = 1 ]; then
 
   run_web_foreground
 fi
+
+validate_radar_device
 
 if [ "$LOCAL_WEB" = 1 ]; then
   API_ENDPOINT="$LOCAL_API_ENDPOINT"

--- a/uploader/src/config_channel.rs
+++ b/uploader/src/config_channel.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use clap::ValueEnum;
 use phoenix_channels_client::{Client, Config, Payload};
 use serde_json::Value;
 use tokio::sync::broadcast;
@@ -11,9 +12,28 @@ use crate::{
     uploader_logger::UploaderLog,
 };
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum RadarDeviceType {
+    #[value(name = "rd03d")]
+    Rd03d,
+    #[value(name = "ld2451")]
+    Ld2451,
+}
+
+impl RadarDeviceType {
+    fn as_wire_value(self) -> &'static str {
+        match self {
+            Self::Rd03d => "rd03d",
+            Self::Ld2451 => "ld2451",
+        }
+    }
+}
+
 pub async fn run(
     api_endpoint: String,
     api_key: String,
+    radar_device: RadarDeviceType,
+    test_mode: bool,
     config_tx: tokio::sync::mpsc::UnboundedSender<RadarConfig>,
     mut target_data_rx: broadcast::Receiver<TargetData>,
     mut uploader_log_rx: broadcast::Receiver<UploaderLog>,
@@ -22,6 +42,8 @@ pub async fn run(
         match connect_and_run(
             &api_endpoint,
             &api_key,
+            radar_device,
+            test_mode,
             &config_tx,
             &mut target_data_rx,
             &mut uploader_log_rx,
@@ -38,6 +60,8 @@ pub async fn run(
 async fn connect_and_run(
     api_endpoint: &str,
     api_key: &str,
+    radar_device: RadarDeviceType,
+    test_mode: bool,
     config_tx: &tokio::sync::mpsc::UnboundedSender<RadarConfig>,
     target_data_rx: &mut broadcast::Receiver<TargetData>,
     uploader_log_rx: &mut broadcast::Receiver<UploaderLog>,
@@ -63,11 +87,23 @@ async fn connect_and_run(
         .map_err(|e| eyre::eyre!("join error: {e}"))?;
     log::info!("Joined radar:config channel");
 
+    let register_reply = channel
+        .send("register_device", register_device_payload(radar_device, test_mode))
+        .await
+        .map_err(|e| channel_send_error("register_device", e))?;
+    ensure_no_device_registration_error("register_device", &register_reply)?;
+    log::info!(
+        "Registered {:?} radar device with config channel (test_mode={})",
+        radar_device,
+        test_mode
+    );
+
     // Request initial config
     let reply = channel
         .send("get_config", serde_json::json!({}))
         .await
-        .map_err(|e| eyre::eyre!("get_config error: {e}"))?;
+        .map_err(|e| channel_send_error("get_config", e))?;
+    ensure_no_device_registration_error("get_config", &reply)?;
     if let Some(config) = parse_config_payload(&reply) {
         let _ = config_tx.send(config);
         log::info!("Received initial config");
@@ -163,6 +199,53 @@ async fn connect_and_run(
     Ok(())
 }
 
+fn register_device_payload(radar_device: RadarDeviceType, test_mode: bool) -> Value {
+    serde_json::json!({
+        "device_type": radar_device.as_wire_value(),
+        "test_mode": test_mode,
+    })
+}
+
+fn channel_send_error(
+    event: &'static str,
+    error: impl std::fmt::Display,
+) -> eyre::Report {
+    let error = error.to_string();
+    if let Some(reason) = known_device_registration_error(&error) {
+        eyre::eyre!("{event} rejected by config channel: {reason}; reconnecting to register device")
+    } else {
+        eyre::eyre!("{event} error: {error}")
+    }
+}
+
+fn ensure_no_device_registration_error(event: &'static str, payload: &Payload) -> eyre::Result<()> {
+    if let Some(reason) = known_device_registration_payload_error(payload) {
+        return Err(eyre::eyre!(
+            "{event} rejected by config channel: {reason}; reconnecting to register device"
+        ));
+    }
+    Ok(())
+}
+
+fn known_device_registration_payload_error(payload: &Payload) -> Option<&'static str> {
+    match payload {
+        Payload::Value(value) => known_device_registration_error(&value.to_string()),
+        Payload::Binary(bytes) => {
+            known_device_registration_error(&String::from_utf8_lossy(bytes))
+        }
+    }
+}
+
+fn known_device_registration_error(text: &str) -> Option<&'static str> {
+    if text.contains("device_not_registered") {
+        Some("device_not_registered")
+    } else if text.contains("device_already_connected") {
+        Some("device_already_connected")
+    } else {
+        None
+    }
+}
+
 fn target_data_payload(data: &TargetData) -> Value {
     serde_json::json!({
         "raw_speed_cm_s": data.raw_speed_cm_s,
@@ -228,6 +311,40 @@ mod tests {
         }
 
         Payload::Value(value)
+    }
+
+    #[test]
+    fn builds_rd03d_real_registration_payload() {
+        assert_eq!(
+            register_device_payload(RadarDeviceType::Rd03d, false),
+            serde_json::json!({
+                "device_type": "rd03d",
+                "test_mode": false,
+            })
+        );
+    }
+
+    #[test]
+    fn builds_ld2451_fake_registration_payload() {
+        assert_eq!(
+            register_device_payload(RadarDeviceType::Ld2451, true),
+            serde_json::json!({
+                "device_type": "ld2451",
+                "test_mode": true,
+            })
+        );
+    }
+
+    #[test]
+    fn recognizes_device_registration_reply_errors() {
+        let payload = Payload::Value(serde_json::json!({
+            "reason": "device_already_connected"
+        }));
+
+        assert_eq!(
+            known_device_registration_payload_error(&payload),
+            Some("device_already_connected")
+        );
     }
 
     #[test]

--- a/uploader/src/main.rs
+++ b/uploader/src/main.rs
@@ -5,7 +5,7 @@ use tokio::sync::broadcast;
 
 use uploader::{
     actor::Actor,
-    config_channel,
+    config_channel::{self, RadarDeviceType},
     fake_radar_reader::FakeRadarReader,
     infraction_recorder::{InfractionRecorder, InfractionRecorderCommand},
     infraction_uploader::InfractionUploader,
@@ -30,6 +30,9 @@ struct Args {
 
     #[arg(long)]
     elf_path: Option<Utf8PathBuf>,
+
+    #[arg(long, value_enum)]
+    radar_device: RadarDeviceType,
 
     #[arg(short, long)]
     infractions_dir: Utf8PathBuf,
@@ -86,11 +89,14 @@ async fn main() -> Result<()> {
     let api_endpoint = args.api_endpoint.clone();
     let api_key = args.api_key.clone();
     let test_mode = args.test_mode;
+    let radar_device = args.radar_device;
 
     // Spawn config channel on a regular tokio task (needs Send)
     tokio::spawn(config_channel::run(
         api_endpoint,
         api_key,
+        radar_device,
+        test_mode,
         config_tx,
         target_data_rx,
         uploader_log_rx,
@@ -149,4 +155,65 @@ async fn main() -> Result<()> {
         .await;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::error::ErrorKind;
+
+    use super::*;
+
+    fn required_args() -> Vec<&'static str> {
+        vec![
+            "uploader",
+            "--api-endpoint",
+            "http://localhost:4000",
+            "--api-key",
+            "secret",
+            "--infractions-dir",
+            "/tmp/infractions",
+        ]
+    }
+
+    #[test]
+    fn radar_device_is_required_in_test_mode() {
+        let mut args = required_args();
+        args.push("--test-mode");
+
+        let err = Args::try_parse_from(args).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn parses_rd03d_radar_device() {
+        let mut args = required_args();
+        args.extend(["--radar-device", "rd03d", "--test-mode"]);
+
+        let args = Args::try_parse_from(args).unwrap();
+
+        assert_eq!(args.radar_device, RadarDeviceType::Rd03d);
+        assert!(args.test_mode);
+    }
+
+    #[test]
+    fn parses_ld2451_radar_device() {
+        let mut args = required_args();
+        args.extend(["--radar-device", "ld2451", "--test-mode"]);
+
+        let args = Args::try_parse_from(args).unwrap();
+
+        assert_eq!(args.radar_device, RadarDeviceType::Ld2451);
+        assert!(args.test_mode);
+    }
+
+    #[test]
+    fn rejects_unknown_radar_device() {
+        let mut args = required_args();
+        args.extend(["--radar-device", "fake", "--test-mode"]);
+
+        let err = Args::try_parse_from(args).unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidValue);
+    }
 }


### PR DESCRIPTION
Beadwork: rc-edm.6

Summary:
- Require one radar device type per uploader connection.
- Register the active radar device after joining the config channel.
- Pass the explicit radar device through start/install workflows, including fake and remote uploader modes.
- Add tests for device registration payloads and CLI validation.

Verification:
- bash -n start.sh
- bash -n install.sh
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo test
- nix develop --command cargo fmt --check (blocked: cargo-fmt is not installed for stable-x86_64-unknown-linux-gnu)