### PR TITLE
radar: Add build-time radar module selection

### DIFF
--- a/radar/Cargo.toml
+++ b/radar/Cargo.toml
@@ -15,6 +15,11 @@ test = false
 doctest = false
 bench = false
 
+[features]
+default = ["rd03d"]
+rd03d = []
+ld2451 = []
+
 [dependencies]
 defmt = "0.3.0"
 esp-bootloader-esp-idf = "0.1.0"

--- a/radar/src/bin/main.rs
+++ b/radar/src/bin/main.rs
@@ -31,7 +31,7 @@ use radar_a_chepers::{
         RadarFrameState, RadarModule, RadarTarget, RadarTargetFrame, MAX_ACK_FRAME_HEADER_LENGTH,
         MAX_TARGET_FRAME_HEADER_LENGTH,
     },
-    rd03d::Rd03d,
+    selected_radar::selected_radar_module,
 };
 use static_cell::StaticCell;
 
@@ -491,7 +491,7 @@ async fn reader(
     mut trigger: Output<'static>,
     trigger_config: &'static SharedTriggerConfig,
 ) {
-    let radar = Rd03d;
+    let radar = selected_radar_module();
     let mut rbuf = [0u8; STREAM_BUF_SIZE];
     let mut chunk = [0u8; READ_BUF_SIZE];
     let mut offset = 0;
@@ -818,7 +818,7 @@ async fn main(spawner: Spawner) {
         .into_async();
     let (config_rx, config_tx) = config_uart.split();
 
-    let radar = Rd03d;
+    let radar = selected_radar_module();
     configure_radar(&radar, &mut tx, &mut rx).await;
 
     spawner

--- a/radar/src/ld2451.rs
+++ b/radar/src/ld2451.rs
@@ -1,0 +1,85 @@
+use crate::radar_module::{RadarModule, RadarTarget, RadarTargetFrame};
+
+pub struct Ld2451;
+
+#[derive(Debug, defmt::Format)]
+pub struct Ld2451Target;
+
+#[derive(Debug, defmt::Format)]
+pub struct Ld2451TargetFrame;
+
+#[derive(Debug, defmt::Format)]
+pub enum Ld2451ParseError {
+    NotImplemented,
+}
+
+impl RadarTarget for Ld2451Target {
+    fn x_mm(&self) -> i16 {
+        0
+    }
+
+    fn y_mm(&self) -> i16 {
+        0
+    }
+
+    fn raw_speed_cm_s(&self) -> i16 {
+        0
+    }
+
+    fn distance_resolution_mm(&self) -> u16 {
+        0
+    }
+}
+
+impl RadarTargetFrame for Ld2451TargetFrame {
+    type Target = Ld2451Target;
+
+    fn targets(&self) -> &[Option<Self::Target>] {
+        &[]
+    }
+}
+
+impl RadarModule for Ld2451 {
+    type TargetFrame = Ld2451TargetFrame;
+    type ParseError = Ld2451ParseError;
+
+    fn target_frame_header_length(&self) -> usize {
+        1
+    }
+
+    fn target_frame_length(&self) -> usize {
+        1
+    }
+
+    fn target_frame_header_position(&self, _buffer: &[u8]) -> Option<usize> {
+        None
+    }
+
+    fn parse_target_frame(&self, _frame: &[u8]) -> Result<Self::TargetFrame, Self::ParseError> {
+        Err(Ld2451ParseError::NotImplemented)
+    }
+
+    fn ack_frame_header_length(&self) -> usize {
+        1
+    }
+
+    fn ack_frame_header_position(&self, _buffer: &[u8]) -> Option<(usize, usize)> {
+        None
+    }
+
+    fn ack_frame_footer(&self) -> &'static [u8] {
+        &[]
+    }
+
+    fn init_command(&self, _index: usize) -> Option<&'static [u8]> {
+        None
+    }
+
+    fn configured_message(&self) -> &'static str {
+        "LD2451 radar module selected; protocol not implemented"
+    }
+
+    fn is_suspicious_speed(&self, _raw_speed_cm_s: i16) -> bool {
+        false
+    }
+}

--- a/radar/src/lib.rs
+++ b/radar/src/lib.rs
@@ -1,5 +1,16 @@
 #![no_std]
+#[cfg(all(feature = "rd03d", feature = "ld2451"))]
+compile_error!(
+    "radar module features are mutually exclusive; enable exactly one of `rd03d` or `ld2451`"
+);
+#[cfg(not(any(feature = "rd03d", feature = "ld2451")))]
+compile_error!("no radar module feature selected; enable exactly one of `rd03d` or `ld2451`");
+
 pub mod command;
+#[cfg(feature = "ld2451")]
+pub mod ld2451;
 pub mod radar_module;
+#[cfg(feature = "rd03d")]
 pub mod rd03d;
+pub mod selected_radar;
 pub mod target;

--- a/radar/src/selected_radar.rs
+++ b/radar/src/selected_radar.rs
@@ -1,0 +1,12 @@
+#[cfg(all(feature = "ld2451", not(feature = "rd03d")))]
+pub use crate::ld2451::Ld2451 as SelectedRadarModule;
+#[cfg(all(feature = "rd03d", not(feature = "ld2451")))]
+pub use crate::rd03d::Rd03d as SelectedRadarModule;
+
+#[cfg(any(
+    all(feature = "rd03d", not(feature = "ld2451")),
+    all(feature = "ld2451", not(feature = "rd03d"))
+))]
+pub fn selected_radar_module() -> SelectedRadarModule {
+    SelectedRadarModule
+}


### PR DESCRIPTION
Beadwork: rc-edm.3

Stacked on: #3

Summary:
- Add mutually exclusive rd03d and ld2451 radar Cargo features, defaulting to rd03d.
- Select the ESP radar module through compile-time feature wiring.
- Add an LD2451 placeholder module so the feature can compile before protocol support lands.

Verification:
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo fmt --check
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo check
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo check --no-default-features --features rd03d
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo check --no-default-features --features ld2451
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo check --no-default-features (expected compile_error)
- nix develop /home/flupke/src/radar-a-chepers/main --command cargo check --all-features (expected compile_error)