### PR TITLE
web: Route config channel by single active radar device

### DIFF
--- a/web/lib/radar/application.ex
+++ b/web/lib/radar/application.ex
@@ -15,6 +15,7 @@ defmodule Radar.Application do
       {DNSCluster, query: Application.get_env(:radar, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Radar.PubSub},
       RadarWeb.Presence,
+      RadarWeb.ActiveRadar,
       Radar.RadarData,
       # Start a worker by calling: Radar.Worker.start_link(arg)
       # {Radar.Worker, arg},

--- a/web/lib/radar_web/active_radar.ex
+++ b/web/lib/radar_web/active_radar.ex
@@ -1,0 +1,72 @@
+defmodule RadarWeb.ActiveRadar do
+  @moduledoc false
+
+  use GenServer
+
+  defstruct [:pid, :monitor_ref, :device_type, :test_mode]
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  def register(pid, device_type, test_mode) when is_pid(pid) do
+    GenServer.call(__MODULE__, {:register, pid, device_type, test_mode})
+  end
+
+  def unregister(pid) when is_pid(pid) do
+    GenServer.call(__MODULE__, {:unregister, pid})
+  end
+
+  @impl true
+  def init(_opts), do: {:ok, nil}
+
+  @impl true
+  def handle_call({:register, pid, device_type, test_mode}, _from, nil) do
+    {:reply, :ok, track(pid, device_type, test_mode)}
+  end
+
+  def handle_call({:register, pid, device_type, test_mode}, _from, %{pid: pid} = state) do
+    if state.device_type == device_type and state.test_mode == test_mode do
+      {:reply, :ok, state}
+    else
+      {:reply, {:error, :device_already_connected}, state}
+    end
+  end
+
+  def handle_call({:register, pid, device_type, test_mode}, _from, state) do
+    if Process.alive?(state.pid) do
+      {:reply, {:error, :device_already_connected}, state}
+    else
+      Process.demonitor(state.monitor_ref, [:flush])
+      {:reply, :ok, track(pid, device_type, test_mode)}
+    end
+  end
+
+  def handle_call({:unregister, pid}, _from, %{pid: pid, monitor_ref: monitor_ref}) do
+    Process.demonitor(monitor_ref, [:flush])
+    {:reply, :ok, nil}
+  end
+
+  def handle_call({:unregister, _pid}, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, monitor_ref, :process, pid, _reason}, %{
+        pid: pid,
+        monitor_ref: monitor_ref
+      }) do
+    {:noreply, nil}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp track(pid, device_type, test_mode) do
+    %__MODULE__{
+      pid: pid,
+      monitor_ref: Process.monitor(pid),
+      device_type: device_type,
+      test_mode: test_mode
+    }
+  end
+end

--- a/web/lib/radar_web/channels/radar_config_channel.ex
+++ b/web/lib/radar_web/channels/radar_config_channel.ex
@@ -6,25 +6,77 @@ defmodule RadarWeb.RadarConfigChannel do
 
   alias Radar.RadarData
   alias Radar.RadarConfigs
+  alias RadarWeb.ActiveRadar
 
   @uploader_debug_topic "uploader_debug"
-  @device_type "rd03d"
 
   @impl true
   def join("radar:config", _payload, socket) do
-    case RadarWeb.Presence.track_uploader(self()) do
-      {:ok, _ref} -> :ok
-      {:error, reason} -> Logger.warning("Failed to track uploader presence: #{inspect(reason)}")
-    end
-
     Phoenix.PubSub.subscribe(Radar.PubSub, "radar_config")
     {:ok, socket}
   end
 
   @impl true
+  def handle_in(
+        "register_device",
+        payload,
+        %{assigns: %{registered_device_type: current_device_type, test_mode: current_test_mode}} =
+          socket
+      ) do
+    with {:ok, device_type, test_mode} <- parse_registration(payload) do
+      if current_device_type == device_type and current_test_mode == test_mode do
+        {:reply, {:ok, %{device_type: device_type, test_mode: test_mode}}, socket}
+      else
+        {:reply, {:error, %{reason: "device_already_connected"}}, socket}
+      end
+    else
+      {:error, :unsupported_device_type} ->
+        {:reply, {:error, %{reason: "unsupported_device_type"}}, socket}
+
+      {:error, :invalid_registration} ->
+        {:reply, {:error, %{reason: "invalid_registration"}}, socket}
+    end
+  end
+
+  def handle_in("register_device", payload, socket) do
+    with {:ok, device_type, test_mode} <- parse_registration(payload),
+         :ok <- ActiveRadar.register(self(), device_type, test_mode),
+         {:ok, _ref} <- track_registered_uploader(device_type, test_mode) do
+      socket =
+        socket
+        |> assign(:registered_device_type, device_type)
+        |> assign(:test_mode, test_mode)
+
+      {:reply, {:ok, %{device_type: device_type, test_mode: test_mode}}, socket}
+    else
+      {:error, :device_already_connected} ->
+        {:reply, {:error, %{reason: "device_already_connected"}}, socket}
+
+      {:error, :unsupported_device_type} ->
+        {:reply, {:error, %{reason: "unsupported_device_type"}}, socket}
+
+      {:error, :invalid_registration} ->
+        {:reply, {:error, %{reason: "invalid_registration"}}, socket}
+
+      {:error, reason} ->
+        ActiveRadar.unregister(self())
+        Logger.warning("Failed to register uploader device: #{inspect(reason)}")
+        {:reply, {:error, %{reason: "device_registration_failed"}}, socket}
+    end
+  end
+
+  @impl true
+  def handle_in(
+        "get_config",
+        _payload,
+        %{assigns: %{registered_device_type: device_type}} = socket
+      ) do
+    config = RadarConfigs.get_config!(device_type)
+    {:reply, {:ok, RadarConfigs.config_payload(device_type, config)}, socket}
+  end
+
   def handle_in("get_config", _payload, socket) do
-    config = RadarConfigs.get_config!(@device_type)
-    {:reply, {:ok, RadarConfigs.config_payload(@device_type, config)}, socket}
+    {:reply, {:error, %{reason: "device_not_registered"}}, socket}
   end
 
   @impl true
@@ -33,13 +85,23 @@ defmodule RadarWeb.RadarConfigChannel do
   end
 
   @impl true
-  def handle_in("target_data", payload, socket) do
+  def handle_in(
+        "target_data",
+        payload,
+        %{assigns: %{registered_device_type: _device_type}} = socket
+      ) do
     RadarData.update_target(payload)
     {:noreply, socket}
   end
 
+  def handle_in("target_data", _payload, socket), do: {:noreply, socket}
+
   @impl true
-  def handle_in("uploader_log", payload, socket) do
+  def handle_in(
+        "uploader_log",
+        payload,
+        %{assigns: %{registered_device_type: _device_type}} = socket
+      ) do
     log = uploader_log(payload)
 
     unless target_message?(log.message) do
@@ -53,13 +115,48 @@ defmodule RadarWeb.RadarConfigChannel do
     {:noreply, socket}
   end
 
+  def handle_in("uploader_log", _payload, socket), do: {:noreply, socket}
+
   @impl true
-  def handle_info({:config_updated, %{device_type: @device_type} = config}, socket) do
-    push(socket, "config_updated", RadarConfigs.config_payload(@device_type, config))
+  def handle_info(
+        {:config_updated, config},
+        %{assigns: %{registered_device_type: device_type}} = socket
+      ) do
+    if config.device_type == device_type do
+      push(socket, "config_updated", RadarConfigs.config_payload(device_type, config))
+    end
+
     {:noreply, socket}
   end
 
   def handle_info({:config_updated, _config}, socket), do: {:noreply, socket}
+
+  @impl true
+  def terminate(_reason, %{assigns: %{registered_device_type: _device_type}}) do
+    ActiveRadar.unregister(self())
+    RadarWeb.Presence.untrack_uploader(self())
+    :ok
+  end
+
+  def terminate(_reason, _socket), do: :ok
+
+  defp parse_registration(%{"device_type" => device_type, "test_mode" => test_mode})
+       when is_binary(device_type) and is_boolean(test_mode) do
+    if device_type in RadarConfigs.supported_device_types() do
+      {:ok, device_type, test_mode}
+    else
+      {:error, :unsupported_device_type}
+    end
+  end
+
+  defp parse_registration(_payload), do: {:error, :invalid_registration}
+
+  defp track_registered_uploader(device_type, test_mode) do
+    RadarWeb.Presence.track_uploader(self(), %{
+      device_type: device_type,
+      test_mode: test_mode
+    })
+  end
 
   defp uploader_log_message(%{"message" => message}), do: message
   defp uploader_log_message(%{"line" => message}), do: message

--- a/web/lib/radar_web/presence.ex
+++ b/web/lib/radar_web/presence.ex
@@ -11,10 +11,13 @@ defmodule RadarWeb.Presence do
   def uploader_topic, do: @uploader_topic
   def uploader_key, do: @uploader_key
 
-  def track_uploader(pid \\ self()) do
-    track(pid, @uploader_topic, @uploader_key, %{
-      online_at: DateTime.utc_now() |> DateTime.to_iso8601()
-    })
+  def track_uploader(pid \\ self(), meta \\ %{}) do
+    meta =
+      meta
+      |> Map.new()
+      |> Map.put(:online_at, DateTime.utc_now() |> DateTime.to_iso8601())
+
+    track(pid, @uploader_topic, @uploader_key, meta)
   end
 
   def untrack_uploader(pid \\ self()) do

--- a/web/test/radar_web/channels/radar_config_channel_test.exs
+++ b/web/test/radar_web/channels/radar_config_channel_test.exs
@@ -6,37 +6,94 @@ defmodule RadarWeb.RadarConfigChannelTest do
   alias RadarWeb.Presence
 
   @uploader_debug_topic "uploader_debug"
-  @device_type "rd03d"
+  @rd03d "rd03d"
+  @ld2451 "ld2451"
 
   setup do
     Radar.RadarData.clear()
     :ok
   end
 
-  test "get_config replies with capture pause state for uploader clients" do
-    assert {:ok, _reply, socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+  test "get_config rejects uploader clients before device registration" do
+    socket = join_uploader()
 
     ref = push(socket, "get_config", %{})
 
-    assert_reply ref, :ok, %{capture_paused: false}
+    assert_reply ref, :error, %{reason: "device_not_registered"}
   end
 
-  test "pushes capture pause updates to joined uploader clients" do
-    assert {:ok, _reply, _socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+  test "get_config replies with config for the registered uploader device" do
+    socket =
+      join_uploader()
+      |> register_device(@ld2451, true)
 
-    assert {:ok, _config} = RadarConfigs.update_config(@device_type, %{capture_paused: true})
+    ref = push(socket, "get_config", %{})
 
-    assert_push "config_updated", %{capture_paused: true}
+    assert_reply ref, :ok, %{
+      device_type: @ld2451,
+      capture_paused: false,
+      aperture_angle: 90
+    }
+  end
+
+  test "rejects a second registered uploader while one is active" do
+    join_uploader()
+    |> register_device(@rd03d, false)
+
+    socket = join_uploader()
+
+    ref =
+      push(socket, "register_device", %{
+        "device_type" => @ld2451,
+        "test_mode" => true
+      })
+
+    assert_reply ref, :error, %{reason: "device_already_connected"}
+
+    ref = push(socket, "get_config", %{})
+    assert_reply ref, :error, %{reason: "device_not_registered"}
+  end
+
+  test "rejects unsupported registered device types" do
+    socket = join_uploader()
+
+    ref =
+      push(socket, "register_device", %{
+        "device_type" => "fake",
+        "test_mode" => false
+      })
+
+    assert_reply ref, :error, %{reason: "unsupported_device_type"}
+  end
+
+  test "allows the active uploader to repeat the same device registration" do
+    socket =
+      join_uploader()
+      |> register_device(@rd03d, false)
+
+    ref =
+      push(socket, "register_device", %{
+        "device_type" => @rd03d,
+        "test_mode" => false
+      })
+
+    assert_reply ref, :ok, %{device_type: @rd03d, test_mode: false}
+  end
+
+  test "pushes config updates only for the registered uploader device" do
+    join_uploader()
+    |> register_device(@ld2451, true)
+
+    assert {:ok, _config} = RadarConfigs.update_config(@rd03d, %{capture_paused: true})
+    refute_push "config_updated", %{device_type: @rd03d}
+
+    assert {:ok, _config} = RadarConfigs.update_config(@ld2451, %{capture_paused: true})
+
+    assert_push "config_updated", %{device_type: @ld2451, capture_paused: true}
   end
 
   test "replies to uploader ping health checks" do
-    assert {:ok, _reply, socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+    socket = join_uploader()
 
     ref = push(socket, "ping", %{})
 
@@ -44,11 +101,11 @@ defmodule RadarWeb.RadarConfigChannelTest do
   end
 
   test "continues forwarding target data while capture is paused" do
-    assert {:ok, _reply, socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+    socket =
+      join_uploader()
+      |> register_device(@rd03d, false)
 
-    assert {:ok, _config} = RadarConfigs.update_config(@device_type, %{capture_paused: true})
+    assert {:ok, _config} = RadarConfigs.update_config(@rd03d, %{capture_paused: true})
     Phoenix.PubSub.subscribe(Radar.PubSub, "radar_data")
 
     push(socket, "target_data", %{"x" => 1, "y" => 2})
@@ -57,25 +114,27 @@ defmodule RadarWeb.RadarConfigChannelTest do
     assert Radar.RadarData.last_target() == %{"x" => 1, "y" => 2}
   end
 
-  test "tracks uploader channel joins" do
+  test "tracks registered uploader devices" do
     Phoenix.PubSub.subscribe(Radar.PubSub, Presence.uploader_topic())
 
-    assert {:ok, _reply, _socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+    join_uploader()
+    |> register_device(@ld2451, true)
 
     assert_receive %Phoenix.Socket.Broadcast{
       event: "presence_diff",
-      payload: %{joins: %{"uploader" => %{metas: [_meta | _]}}}
+      payload: %{joins: %{"uploader" => %{metas: [meta | _]}}}
     }
+
+    assert meta.device_type == @ld2451
+    assert meta.test_mode == true
   end
 
   test "accepts live uploader logs" do
     Phoenix.PubSub.subscribe(Radar.PubSub, @uploader_debug_topic)
 
-    assert {:ok, _reply, socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+    socket =
+      join_uploader()
+      |> register_device(@rd03d, false)
 
     push(socket, "uploader_log", %{"message" => "radar booted", "level" => "debug"})
 
@@ -87,9 +146,9 @@ defmodule RadarWeb.RadarConfigChannelTest do
   test "ignores target frames submitted as uploader logs" do
     Phoenix.PubSub.subscribe(Radar.PubSub, @uploader_debug_topic)
 
-    assert {:ok, _reply, socket} =
-             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
-             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+    socket =
+      join_uploader()
+      |> register_device(@rd03d, false)
 
     push(socket, "uploader_log", %{
       "message" => "EVENTS: TARGET: 150 0 100",
@@ -97,5 +156,27 @@ defmodule RadarWeb.RadarConfigChannelTest do
     })
 
     refute_receive {:uploader_log, _log}
+  end
+
+  defp join_uploader do
+    assert {:ok, _reply, socket} =
+             Phoenix.ChannelTest.socket(RadarWeb.UploaderSocket, "uploader_socket", %{})
+             |> subscribe_and_join(RadarConfigChannel, "radar:config")
+
+    socket
+  end
+
+  defp register_device(socket, device_type, test_mode) do
+    ref =
+      push(socket, "register_device", %{
+        "device_type" => device_type,
+        "test_mode" => test_mode
+      })
+
+    assert_reply ref, :ok, payload
+    assert payload.device_type == device_type
+    assert payload.test_mode == test_mode
+
+    socket
   end
 end


### PR DESCRIPTION
Beadwork: rc-edm.8

Stacked on: #2

Summary:
- Add an ActiveRadar registry for the single registered uploader connection.
- Require register_device before get_config, target data, or uploader logs are accepted.
- Scope config replies and config_updated pushes to the registered device_type.
- Reject a second active uploader with device_already_connected.

Verification:
- mix format --check-formatted
- mix test test/radar/radar_configs_test.exs test/radar_web/channels/radar_config_channel_test.exs test/radar_web/live/admin_live_test.exs
- mix test