### PR TITLE
web: Add device-specific admin configuration UI

### DIFF
--- a/web/lib/radar_web/active_radar.ex
+++ b/web/lib/radar_web/active_radar.ex
@@ -17,10 +17,25 @@ defmodule RadarWeb.ActiveRadar do
     GenServer.call(__MODULE__, {:unregister, pid})
   end
 
+  def current do
+    GenServer.call(__MODULE__, :current)
+  end
+
   @impl true
   def init(_opts), do: {:ok, nil}
 
   @impl true
+  def handle_call(:current, _from, nil), do: {:reply, nil, nil}
+
+  def handle_call(:current, _from, state) do
+    if Process.alive?(state.pid) do
+      {:reply, active_radar(state), state}
+    else
+      Process.demonitor(state.monitor_ref, [:flush])
+      {:reply, nil, nil}
+    end
+  end
+
   def handle_call({:register, pid, device_type, test_mode}, _from, nil) do
     {:reply, :ok, track(pid, device_type, test_mode)}
   end
@@ -60,6 +75,13 @@ defmodule RadarWeb.ActiveRadar do
   end
 
   def handle_info(_message, state), do: {:noreply, state}
+
+  defp active_radar(state) do
+    %{
+      device_type: state.device_type,
+      test_mode: state.test_mode
+    }
+  end
 
   defp track(pid, device_type, test_mode) do
     %__MODULE__{

--- a/web/lib/radar_web/live/admin_radar_config_live.ex
+++ b/web/lib/radar_web/live/admin_radar_config_live.ex
@@ -5,11 +5,12 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
   alias Radar.{Infractions, RadarConfigs, RadarData}
   alias Phoenix.LiveView.ColocatedHook
+  alias RadarWeb.ActiveRadar
   alias RadarWeb.Presence
 
   @max_uploader_logs 100
   @uploader_debug_topic "uploader_debug"
-  @device_type "rd03d"
+  @default_device_type "rd03d"
 
   def mount(_params, _session, socket) do
     if connected?(socket) do
@@ -20,12 +21,16 @@ defmodule RadarWeb.AdminRadarConfigLive do
       Phoenix.PubSub.subscribe(Radar.PubSub, Presence.uploader_topic())
     end
 
-    config = RadarConfigs.get_config!(@device_type)
+    active_radar = ActiveRadar.current()
+    selected_device_type = selected_device_type(active_radar)
+    config = RadarConfigs.get_config!(selected_device_type)
     last_target = last_known_target()
 
     socket =
       socket
-      |> assign(:device_type, @device_type)
+      |> assign(:supported_device_types, RadarConfigs.supported_device_types())
+      |> assign(:selected_device_type, selected_device_type)
+      |> assign(:active_radar, active_radar)
       |> assign(:config, config)
       |> assign(:form, config_to_form(config))
       |> assign(:infraction_count, Infractions.count_infractions())
@@ -70,6 +75,36 @@ defmodule RadarWeb.AdminRadarConfigLive do
                 <.icon name={capture_button_icon(@config)} class="size-4" />
                 {capture_button_label(@config)}
               </button>
+            </div>
+
+            <div class="grid gap-3 rounded-lg bg-base-300 p-3 text-sm sm:grid-cols-[1fr_auto] sm:items-center">
+              <div id="active-device-status">
+                <span class="opacity-70">Active device</span>
+                <div :if={@active_radar} class="mt-1 flex flex-wrap items-center gap-2">
+                  <span class="font-mono">{device_label(@active_radar.device_type)}</span>
+                  <span class={test_mode_badge_class(@active_radar.test_mode)}>
+                    {test_mode_label(@active_radar.test_mode)}
+                  </span>
+                </div>
+                <div :if={!@active_radar} class="mt-1 font-mono">No device connected</div>
+              </div>
+              <div id="device-config-selector" class="flex flex-wrap gap-2">
+                <button
+                  :for={device_type <- @supported_device_types}
+                  type="button"
+                  phx-click="select_device"
+                  phx-value-device={device_type}
+                  class={device_button_class(device_type, @selected_device_type, @active_radar)}
+                >
+                  {device_label(device_type)}
+                  <span
+                    :if={active_device?(device_type, @active_radar)}
+                    class="badge badge-success badge-sm"
+                  >
+                    active
+                  </span>
+                </button>
+              </div>
             </div>
 
             <.form for={@form} phx-change="update_config" class="space-y-5">
@@ -124,7 +159,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
               id="radar-canvas"
               phx-hook=".RadarCanvas"
               phx-update="ignore"
-              data-radar-config={Jason.encode!(RadarConfigs.config_payload(@device_type, @config))}
+              data-radar-config={
+                Jason.encode!(RadarConfigs.config_payload(@selected_device_type, @config))
+              }
               width="600"
               height="400"
               class="w-full rounded-lg"
@@ -352,10 +389,26 @@ defmodule RadarWeb.AdminRadarConfigLive do
     """
   end
 
+  def handle_event("select_device", %{"device" => device_type}, socket) do
+    if device_type in socket.assigns.supported_device_types do
+      config = RadarConfigs.get_config!(device_type)
+
+      {:noreply,
+       socket
+       |> assign(:selected_device_type, device_type)
+       |> assign(:config, config)
+       |> assign(:form, config_to_form(config))
+       |> push_config_event(config)}
+    else
+      {:noreply, socket}
+    end
+  end
+
   def handle_event("update_config", %{"config" => params}, socket) do
     db_params = form_params_to_db(params)
+    device_type = socket.assigns.selected_device_type
 
-    case RadarConfigs.update_config(@device_type, db_params) do
+    case RadarConfigs.update_config(device_type, db_params) do
       {:ok, config} ->
         {:noreply,
          socket
@@ -369,7 +422,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   def handle_event("toggle_capture", _params, socket) do
-    case RadarConfigs.update_config(@device_type, %{
+    device_type = socket.assigns.selected_device_type
+
+    case RadarConfigs.update_config(device_type, %{
            capture_paused: !socket.assigns.config.capture_paused
          }) do
       {:ok, config} ->
@@ -384,15 +439,17 @@ defmodule RadarWeb.AdminRadarConfigLive do
     end
   end
 
-  def handle_info({:config_updated, %{device_type: @device_type} = config}, socket) do
-    {:noreply,
-     socket
-     |> assign(:config, config)
-     |> assign(:form, config_to_form(config))
-     |> push_config_event(config)}
+  def handle_info({:config_updated, %{device_type: device_type} = config}, socket) do
+    if device_type == socket.assigns.selected_device_type do
+      {:noreply,
+       socket
+       |> assign(:config, config)
+       |> assign(:form, config_to_form(config))
+       |> push_config_event(config)}
+    else
+      {:noreply, socket}
+    end
   end
-
-  def handle_info({:config_updated, _config}, socket), do: {:noreply, socket}
 
   def handle_info({:new_infraction, _infraction}, socket) do
     {:noreply, assign(socket, :infraction_count, Infractions.count_infractions())}
@@ -419,7 +476,10 @@ defmodule RadarWeb.AdminRadarConfigLive do
             socket.assigns.uploader_debug.connected
         end
 
-      {:noreply, update(socket, :uploader_debug, &%{&1 | connected: connected})}
+      {:noreply,
+       socket
+       |> update(:uploader_debug, &%{&1 | connected: connected})
+       |> refresh_active_radar()}
     else
       {:noreply, socket}
     end
@@ -464,6 +524,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
   defp parse_page(_page), do: 1
 
+  defp selected_device_type(%{device_type: device_type}), do: device_type
+  defp selected_device_type(_active_radar), do: @default_device_type
+
   defp config_to_form(config) do
     to_form(
       %{
@@ -490,6 +553,33 @@ defmodule RadarWeb.AdminRadarConfigLive do
       "aperture_angle" => params["aperture_angle"]
     }
   end
+
+  defp active_device?(device_type, %{device_type: device_type}), do: true
+  defp active_device?(_device_type, _active_radar), do: false
+
+  defp device_label("rd03d"), do: "RD03-D"
+  defp device_label("ld2451"), do: "LD2451"
+  defp device_label(device_type), do: String.upcase(device_type)
+
+  defp device_button_class(device_type, selected_device_type, active_radar) do
+    selected? = device_type == selected_device_type
+    active? = active_device?(device_type, active_radar)
+
+    [
+      "btn btn-sm",
+      selected? && "btn-primary",
+      !selected? && active? && "btn-success btn-outline",
+      !selected? && !active? && "btn-ghost"
+    ]
+    |> Enum.filter(& &1)
+    |> Enum.join(" ")
+  end
+
+  defp test_mode_label(true), do: "Test mode"
+  defp test_mode_label(false), do: "Live hardware"
+
+  defp test_mode_badge_class(true), do: "badge badge-warning"
+  defp test_mode_badge_class(false), do: "badge badge-info"
 
   defp capture_status(%{capture_paused: true}), do: "paused"
   defp capture_status(_config), do: "active"
@@ -610,6 +700,10 @@ defmodule RadarWeb.AdminRadarConfigLive do
     }
   end
 
+  defp refresh_active_radar(socket) do
+    assign(socket, :active_radar, ActiveRadar.current())
+  end
+
   attr :field, Phoenix.HTML.FormField, required: true
   attr :label, :string, required: true
   attr :unit, :string, required: true
@@ -641,7 +735,11 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   defp push_config_event(socket, config) do
-    push_event(socket, "radar_config", RadarConfigs.config_payload(@device_type, config))
+    push_event(
+      socket,
+      "radar_config",
+      RadarConfigs.config_payload(socket.assigns.selected_device_type, config)
+    )
   end
 
   defp parse_float(val) when is_binary(val) do

--- a/web/test/radar_web/live/admin_live_test.exs
+++ b/web/test/radar_web/live/admin_live_test.exs
@@ -5,10 +5,12 @@ defmodule RadarWeb.AdminLiveTest do
   import Radar.PhotosFixtures
 
   alias Radar.{RadarConfigs, Repo}
+  alias RadarWeb.ActiveRadar
   alias RadarWeb.Presence
 
   @uploader_debug_topic "uploader_debug"
-  @device_type "rd03d"
+  @rd03d "rd03d"
+  @ld2451 "ld2451"
 
   setup do
     Repo.delete_all(Radar.Infraction)
@@ -28,6 +30,9 @@ defmodule RadarWeb.AdminLiveTest do
     |> assert_has("h2", "Live Radar Data")
     |> assert_has("h2", "Uploader Status")
     |> assert_has("#uploader-connected", "No")
+    |> assert_has("#active-device-status", "No device connected")
+    |> assert_has("#device-config-selector", "RD03-D")
+    |> assert_has("#device-config-selector", "LD2451")
     |> assert_has("#radar-canvas")
     |> assert_has("#last-target", "No targets yet.")
   end
@@ -53,18 +58,18 @@ defmodule RadarWeb.AdminLiveTest do
     |> assert_has("#uploader-connected", "Yes")
   end
 
-  test "shows uploader connected when the uploader joined before the admin page mounted", %{
+  test "shows active uploader device when it registered before the admin page mounted", %{
     conn: conn
   } do
-    uploader_pid = self()
-
-    {:ok, _ref} = Presence.track_uploader(uploader_pid)
-    on_exit(fn -> Presence.untrack_uploader(uploader_pid) end)
+    track_active_device(@ld2451, true)
 
     conn
     |> log_in_admin()
     |> visit(~p"/admin")
     |> assert_has("#uploader-connected", "Yes")
+    |> assert_has("#active-device-status", "LD2451")
+    |> assert_has("#active-device-status", "Test mode")
+    |> assert_has("#device-config-selector .btn-primary", "LD2451")
   end
 
   test "marks uploader connected when logs arrive", %{conn: conn} do
@@ -141,7 +146,7 @@ defmodule RadarWeb.AdminLiveTest do
         |> Phoenix.LiveViewTest.render_change()
       end)
 
-    config = RadarConfigs.get_config!(@device_type)
+    config = RadarConfigs.get_config!(@rd03d)
 
     assert config.authorized_speed == 55
     assert config.min_dist == 6500
@@ -160,6 +165,49 @@ defmodule RadarWeb.AdminLiveTest do
     |> assert_has("#radar-canvas[data-radar-config]")
   end
 
+  test "loads and saves the selected device configuration", %{conn: conn} do
+    params = %{
+      "authorized_speed" => "35",
+      "min_dist" => "1.5",
+      "max_dist" => "8.0",
+      "trigger_cooldown" => "1.8",
+      "aperture_angle" => "110"
+    }
+
+    session =
+      conn
+      |> log_in_admin()
+      |> visit(~p"/admin")
+      |> unwrap(fn view ->
+        view
+        |> Phoenix.LiveViewTest.element("button[phx-value-device='ld2451']")
+        |> Phoenix.LiveViewTest.render_click()
+
+        view
+        |> Phoenix.LiveViewTest.form("form", config: params)
+        |> Phoenix.LiveViewTest.render_change()
+      end)
+
+    ld2451_config = RadarConfigs.get_config!(@ld2451)
+    rd03d_config = RadarConfigs.get_config!(@rd03d)
+
+    assert ld2451_config.authorized_speed == 35
+    assert ld2451_config.min_dist == 1500
+    assert ld2451_config.max_dist == 8000
+    assert ld2451_config.trigger_cooldown == 1800
+    assert ld2451_config.aperture_angle == 110
+
+    assert rd03d_config.authorized_speed == 25
+    assert rd03d_config.min_dist == 0
+    assert rd03d_config.max_dist == 10_000
+
+    session
+    |> assert_has("#device-config-selector .btn-primary", "LD2451")
+    |> assert_has("output", "1.5 m")
+    |> assert_has("output", "8.0 m")
+    |> assert_has("output", "110 degrees")
+  end
+
   test "pauses and resumes camera capture from radar configuration", %{conn: conn} do
     session =
       conn
@@ -168,7 +216,7 @@ defmodule RadarWeb.AdminLiveTest do
       |> assert_has("p", "Camera capture is active.")
       |> assert_has("button[aria-pressed='false']", "Pause radar")
 
-    assert RadarConfigs.config_payload(@device_type).capture_paused == false
+    assert RadarConfigs.config_payload(@rd03d).capture_paused == false
 
     session =
       session
@@ -176,14 +224,14 @@ defmodule RadarWeb.AdminLiveTest do
       |> assert_has("p", "Camera capture is paused.")
       |> assert_has("button[aria-pressed='true']", "Resume radar")
 
-    assert RadarConfigs.config_payload(@device_type).capture_paused == true
+    assert RadarConfigs.config_payload(@rd03d).capture_paused == true
 
     session
     |> click_button("Resume radar")
     |> assert_has("p", "Camera capture is active.")
     |> assert_has("button[aria-pressed='false']", "Pause radar")
 
-    assert RadarConfigs.config_payload(@device_type).capture_paused == false
+    assert RadarConfigs.config_payload(@rd03d).capture_paused == false
   end
 
   test "lists infractions with individual photo links and a reliable page archive", %{conn: conn} do
@@ -392,5 +440,22 @@ defmodule RadarWeb.AdminLiveTest do
     id
     |> to_string()
     |> String.slice(0, 8)
+  end
+
+  defp track_active_device(device_type, test_mode) do
+    uploader_pid = self()
+
+    {:ok, _ref} =
+      Presence.track_uploader(uploader_pid, %{
+        device_type: device_type,
+        test_mode: test_mode
+      })
+
+    :ok = ActiveRadar.register(uploader_pid, device_type, test_mode)
+
+    on_exit(fn ->
+      Presence.untrack_uploader(uploader_pid)
+      ActiveRadar.unregister(uploader_pid)
+    end)
   end
 end


### PR DESCRIPTION
Beadwork: rc-edm.9

Stacked on: #6

Summary:
- Show active registered radar device and test-mode state in the admin config screen.
- Add RD03-D and LD2451 selector buttons for stored per-device configs.
- Load, save, pause, and resume the selected device configuration.
- Highlight the active connected device and show No device connected when absent.

Verification:
- mix format --check-formatted
- mix test test/radar/radar_configs_test.exs test/radar_web/channels/radar_config_channel_test.exs test/radar_web/live/admin_live_test.exs
- mix test