### PR TITLE
web: Add device-specific radar debug UI

### DIFF
--- a/web/lib/radar_web/channels/radar_config_channel.ex
+++ b/web/lib/radar_web/channels/radar_config_channel.ex
@@ -88,8 +88,13 @@ defmodule RadarWeb.RadarConfigChannel do
   def handle_in(
         "target_data",
         payload,
-        %{assigns: %{registered_device_type: _device_type}} = socket
+        %{assigns: %{registered_device_type: device_type, test_mode: test_mode}} = socket
       ) do
+    payload =
+      payload
+      |> Map.put("device_type", device_type)
+      |> Map.put("test_mode", test_mode)
+
     RadarData.update_target(payload)
     {:noreply, socket}
   end

--- a/web/lib/radar_web/live/admin_radar_config_live.ex
+++ b/web/lib/radar_web/live/admin_radar_config_live.ex
@@ -24,7 +24,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
     active_radar = ActiveRadar.current()
     selected_device_type = selected_device_type(active_radar)
     config = RadarConfigs.get_config!(selected_device_type)
-    last_target = last_known_target()
+    debug_device_type = debug_device_type(active_radar, selected_device_type)
+    debug_config = RadarConfigs.get_config!(debug_device_type)
+    last_target = last_known_target(active_radar)
 
     socket =
       socket
@@ -32,11 +34,13 @@ defmodule RadarWeb.AdminRadarConfigLive do
       |> assign(:selected_device_type, selected_device_type)
       |> assign(:active_radar, active_radar)
       |> assign(:config, config)
+      |> assign(:debug_device_type, debug_device_type)
+      |> assign(:debug_config, debug_config)
       |> assign(:form, config_to_form(config))
       |> assign(:infraction_count, Infractions.count_infractions())
       |> assign(:uploader_debug, %{connected: Presence.uploader_connected?(), logs: []})
       |> assign(:last_target, last_target)
-      |> push_config_event(config)
+      |> push_debug_config_event()
 
     {:ok, socket}
   end
@@ -160,7 +164,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
               phx-hook=".RadarCanvas"
               phx-update="ignore"
               data-radar-config={
-                Jason.encode!(RadarConfigs.config_payload(@selected_device_type, @config))
+                Jason.encode!(RadarConfigs.config_payload(@debug_device_type, @debug_config))
               }
               width="600"
               height="400"
@@ -277,6 +281,10 @@ defmodule RadarWeb.AdminRadarConfigLive do
               <p :if={!@last_target} class="opacity-70">No targets yet.</p>
               <div :if={@last_target} class="grid gap-3 lg:grid-cols-2">
                 <div class="grid grid-cols-2 gap-x-4 gap-y-1">
+                  <span class="opacity-70">Device</span>
+                  <span class="font-mono">{device_label(@last_target.device_type)}</span>
+                  <span class="opacity-70">Mode</span>
+                  <span class="font-mono">{test_mode_label(@last_target.test_mode)}</span>
                   <span class="opacity-70">Speed</span>
                   <span class="font-mono">
                     {@last_target.speed} km/h ({@last_target.raw_speed_cm_s} cm/s)
@@ -303,9 +311,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
                   <span class={debug_bool_class(@last_target.over_speed)}>
                     {yes_no(@last_target.over_speed)}
                   </span>
-                  <span class="opacity-70">RD03-D sentinel</span>
-                  <span class={debug_bool_class(!@last_target.suspicious_speed)}>
-                    {yes_no(@last_target.suspicious_speed)}
+                  <span class="opacity-70">{target_diagnostic_label(@last_target)}</span>
+                  <span class={target_diagnostic_class(@last_target)}>
+                    {target_diagnostic_value(@last_target)}
                   </span>
                   <span class="opacity-70">Cooldown</span>
                   <span class={debug_bool_class(@last_target.cooldown_elapsed)}>
@@ -342,6 +350,23 @@ defmodule RadarWeb.AdminRadarConfigLive do
                 <span class={uploader_status_class(@uploader_debug.connected)}>
                   {yes_no(@uploader_debug.connected)}
                 </span>
+              </div>
+            </div>
+            <div
+              id="uploader-device"
+              class="grid gap-2 rounded-lg bg-base-300 p-3 text-sm sm:grid-cols-2"
+            >
+              <div>
+                <span class="opacity-70">Device</span>
+                <div class="font-mono">
+                  {if @active_radar, do: device_label(@active_radar.device_type), else: "--"}
+                </div>
+              </div>
+              <div>
+                <span class="opacity-70">Mode</span>
+                <div class="font-mono">
+                  {if @active_radar, do: test_mode_label(@active_radar.test_mode), else: "--"}
+                </div>
               </div>
             </div>
 
@@ -398,7 +423,8 @@ defmodule RadarWeb.AdminRadarConfigLive do
        |> assign(:selected_device_type, device_type)
        |> assign(:config, config)
        |> assign(:form, config_to_form(config))
-       |> push_config_event(config)}
+       |> maybe_follow_selected_debug_config(config)
+       |> push_debug_config_event()}
     else
       {:noreply, socket}
     end
@@ -414,7 +440,8 @@ defmodule RadarWeb.AdminRadarConfigLive do
          socket
          |> assign(:config, config)
          |> assign(:form, config_to_form(config))
-         |> push_config_event(config)}
+         |> maybe_assign_debug_config(config)
+         |> push_debug_config_event()}
 
       {:error, _changeset} ->
         {:noreply, assign(socket, :form, to_form(params, as: :config))}
@@ -432,7 +459,8 @@ defmodule RadarWeb.AdminRadarConfigLive do
          socket
          |> assign(:config, config)
          |> assign(:form, config_to_form(config))
-         |> push_config_event(config)}
+         |> maybe_assign_debug_config(config)
+         |> push_debug_config_event()}
 
       {:error, _changeset} ->
         {:noreply, socket}
@@ -440,16 +468,28 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   def handle_info({:config_updated, %{device_type: device_type} = config}, socket) do
-    if device_type == socket.assigns.selected_device_type do
-      {:noreply,
-       socket
-       |> assign(:config, config)
-       |> assign(:form, config_to_form(config))
-       |> push_config_event(config)}
-    else
-      {:noreply, socket}
-    end
+    socket =
+      if device_type == socket.assigns.selected_device_type do
+        socket
+        |> assign(:config, config)
+        |> assign(:form, config_to_form(config))
+      else
+        socket
+      end
+
+    socket =
+      if device_type == socket.assigns.debug_device_type do
+        socket
+        |> assign(:debug_config, config)
+        |> push_debug_config_event()
+      else
+        socket
+      end
+
+    {:noreply, socket}
   end
+
+  def handle_info({:config_updated, _config}, socket), do: {:noreply, socket}
 
   def handle_info({:new_infraction, _infraction}, socket) do
     {:noreply, assign(socket, :infraction_count, Infractions.count_infractions())}
@@ -490,7 +530,8 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   def handle_info({:target_data, data}, socket) do
-    target = normalize_target_data(data)
+    active_radar = ActiveRadar.current()
+    target = normalize_target_data(data, active_radar)
 
     socket =
       if socket.assigns.uploader_debug.connected do
@@ -501,6 +542,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
     {:noreply,
      socket
+     |> sync_debug_device(active_radar)
      |> assign(:last_target, target)
      |> push_event(
        "radar_point",
@@ -526,6 +568,9 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
   defp selected_device_type(%{device_type: device_type}), do: device_type
   defp selected_device_type(_active_radar), do: @default_device_type
+
+  defp debug_device_type(%{device_type: device_type}, _selected_device_type), do: device_type
+  defp debug_device_type(_active_radar, selected_device_type), do: selected_device_type
 
   defp config_to_form(config) do
     to_form(
@@ -577,6 +622,7 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
   defp test_mode_label(true), do: "Test mode"
   defp test_mode_label(false), do: "Live hardware"
+  defp test_mode_label(_test_mode), do: "--"
 
   defp test_mode_badge_class(true), do: "badge badge-warning"
   defp test_mode_badge_class(false), do: "badge badge-info"
@@ -604,6 +650,18 @@ defmodule RadarWeb.AdminRadarConfigLive do
   defp debug_bool_class(true), do: "font-mono text-success"
   defp debug_bool_class(false), do: "font-mono text-error"
 
+  defp target_diagnostic_label(%{device_type: "rd03d"}), do: "Speed sentinel"
+  defp target_diagnostic_label(%{device_type: "ld2451"}), do: "Radar diagnostic"
+  defp target_diagnostic_label(_target), do: "Radar diagnostic"
+
+  defp target_diagnostic_value(%{device_type: "rd03d", suspicious_speed: true}), do: "Detected"
+  defp target_diagnostic_value(%{device_type: "rd03d"}), do: "Clear"
+  defp target_diagnostic_value(%{suspicious_speed: true}), do: "Review target"
+  defp target_diagnostic_value(_target), do: "Normal"
+
+  defp target_diagnostic_class(%{suspicious_speed: suspicious_speed}),
+    do: debug_bool_class(!suspicious_speed)
+
   defp uploader_status_class(true), do: "badge badge-success"
   defp uploader_status_class(false), do: "badge badge-error"
 
@@ -628,8 +686,10 @@ defmodule RadarWeb.AdminRadarConfigLive do
 
   defp format_degrees(_value), do: "--"
 
-  defp normalize_target_data(data) do
+  defp normalize_target_data(data, active_radar) do
     %{
+      device_type: target_text(data, "device_type", active_device_type(active_radar)),
+      test_mode: target_test_mode(data, active_radar),
       raw_speed_cm_s: target_number(data, "raw_speed_cm_s", 0),
       speed: target_number(data, "speed", 0),
       suspicious_speed: target_bool(data, "suspicious_speed"),
@@ -648,30 +708,82 @@ defmodule RadarWeb.AdminRadarConfigLive do
     }
   end
 
-  defp last_known_target do
+  defp last_known_target(active_radar) do
     case RadarData.last_target() do
       nil -> nil
-      target -> normalize_target_data(target)
+      target -> normalize_target_data(target, active_radar)
     end
   end
 
   defp target_number(data, key, default) do
-    case Map.get(data, key, Map.get(data, String.to_existing_atom(key), default)) do
+    case target_value(data, key, default) do
       value when is_number(value) -> value
       _value -> default
     end
-  rescue
-    ArgumentError -> Map.get(data, key, default)
   end
 
   defp target_bool(data, key) do
-    case Map.get(data, key, Map.get(data, String.to_existing_atom(key), false)) do
-      true -> true
-      _value -> false
+    case target_bool_value(data, key) do
+      {:ok, value} -> value
+      :error -> false
     end
-  rescue
-    ArgumentError -> Map.get(data, key, false) == true
   end
+
+  defp target_test_mode(data, active_radar) do
+    case target_bool_value(data, "test_mode") do
+      {:ok, value} -> value
+      :error -> active_test_mode(active_radar)
+    end
+  end
+
+  defp target_text(data, key, default) do
+    case target_value(data, key, default) do
+      value when is_binary(value) -> value
+      _value -> default
+    end
+  end
+
+  defp target_bool_value(data, key) do
+    case target_lookup(data, key) do
+      {:ok, true} -> {:ok, true}
+      {:ok, _value} -> {:ok, false}
+      :error -> :error
+    end
+  end
+
+  defp target_value(data, key, default) do
+    case target_lookup(data, key) do
+      {:ok, value} -> value
+      :error -> default
+    end
+  end
+
+  defp target_lookup(data, key) do
+    atom_key = existing_atom_key(key)
+
+    cond do
+      Map.has_key?(data, key) ->
+        {:ok, Map.fetch!(data, key)}
+
+      atom_key && Map.has_key?(data, atom_key) ->
+        {:ok, Map.fetch!(data, atom_key)}
+
+      true ->
+        :error
+    end
+  end
+
+  defp existing_atom_key(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp active_device_type(%{device_type: device_type}), do: device_type
+  defp active_device_type(_active_radar), do: @default_device_type
+
+  defp active_test_mode(%{test_mode: test_mode}) when is_boolean(test_mode), do: test_mode
+  defp active_test_mode(_active_radar), do: nil
 
   defp append_uploader_log(debug, log) do
     logs =
@@ -701,7 +813,24 @@ defmodule RadarWeb.AdminRadarConfigLive do
   end
 
   defp refresh_active_radar(socket) do
-    assign(socket, :active_radar, ActiveRadar.current())
+    active_radar = ActiveRadar.current()
+
+    sync_debug_device(socket, active_radar)
+  end
+
+  defp sync_debug_device(socket, active_radar) do
+    debug_device_type = debug_device_type(active_radar, socket.assigns.selected_device_type)
+
+    socket = assign(socket, :active_radar, active_radar)
+
+    if debug_device_type == socket.assigns.debug_device_type do
+      socket
+    else
+      socket
+      |> assign(:debug_device_type, debug_device_type)
+      |> assign(:debug_config, RadarConfigs.get_config!(debug_device_type))
+      |> push_debug_config_event()
+    end
   end
 
   attr :field, Phoenix.HTML.FormField, required: true
@@ -734,11 +863,29 @@ defmodule RadarWeb.AdminRadarConfigLive do
     """
   end
 
-  defp push_config_event(socket, config) do
+  defp maybe_assign_debug_config(socket, %{device_type: device_type} = config) do
+    if device_type == socket.assigns.debug_device_type do
+      assign(socket, :debug_config, config)
+    else
+      socket
+    end
+  end
+
+  defp maybe_follow_selected_debug_config(socket, config) do
+    if socket.assigns.active_radar do
+      socket
+    else
+      socket
+      |> assign(:debug_device_type, socket.assigns.selected_device_type)
+      |> assign(:debug_config, config)
+    end
+  end
+
+  defp push_debug_config_event(socket) do
     push_event(
       socket,
       "radar_config",
-      RadarConfigs.config_payload(socket.assigns.selected_device_type, config)
+      RadarConfigs.config_payload(socket.assigns.debug_device_type, socket.assigns.debug_config)
     )
   end
 

--- a/web/test/radar_web/channels/radar_config_channel_test.exs
+++ b/web/test/radar_web/channels/radar_config_channel_test.exs
@@ -110,8 +110,16 @@ defmodule RadarWeb.RadarConfigChannelTest do
 
     push(socket, "target_data", %{"x" => 1, "y" => 2})
 
-    assert_receive {:target_data, %{"x" => 1, "y" => 2}}
-    assert Radar.RadarData.last_target() == %{"x" => 1, "y" => 2}
+    assert_receive {:target_data, payload}
+
+    assert Map.take(payload, ["x", "y", "device_type", "test_mode"]) == %{
+             "x" => 1,
+             "y" => 2,
+             "device_type" => @rd03d,
+             "test_mode" => false
+           }
+
+    assert Radar.RadarData.last_target() == payload
   end
 
   test "tracks registered uploader devices" do

--- a/web/test/radar_web/live/admin_live_test.exs
+++ b/web/test/radar_web/live/admin_live_test.exs
@@ -69,6 +69,8 @@ defmodule RadarWeb.AdminLiveTest do
     |> assert_has("#uploader-connected", "Yes")
     |> assert_has("#active-device-status", "LD2451")
     |> assert_has("#active-device-status", "Test mode")
+    |> assert_has("#uploader-device", "LD2451")
+    |> assert_has("#uploader-device", "Test mode")
     |> assert_has("#device-config-selector .btn-primary", "LD2451")
   end
 
@@ -122,7 +124,60 @@ defmodule RadarWeb.AdminLiveTest do
     |> assert_has("#last-target", "3 km/h")
     |> assert_has("#last-target", "83 cm/s")
     |> assert_has("#last-target", "Over speed")
-    |> assert_has("#last-target", "RD03-D sentinel")
+    |> assert_has("#last-target", "RD03-D")
+    |> assert_has("#last-target", "Speed sentinel")
+    |> assert_has("#last-target", "Detected")
+  end
+
+  test "shows active device diagnostics while switching stored config tabs", %{conn: conn} do
+    track_active_device(@ld2451, true)
+
+    session =
+      conn
+      |> log_in_admin()
+      |> visit(~p"/admin")
+      |> assert_has("#uploader-device", "LD2451")
+      |> assert_has("#uploader-device", "Test mode")
+
+    Phoenix.PubSub.broadcast(Radar.PubSub, "radar_data", {
+      :target_data,
+      %{
+        "raw_speed_cm_s" => 140,
+        "x" => 100,
+        "y" => 2000,
+        "speed" => 5,
+        "distance" => 2100,
+        "angle" => 2.9,
+        "in_range" => true,
+        "in_aperture" => true,
+        "over_speed" => false,
+        "suspicious_speed" => false,
+        "cooldown_elapsed" => true,
+        "capture_paused" => false,
+        "capture_in_progress" => false,
+        "would_trigger" => false,
+        "triggered" => false
+      }
+    })
+
+    session =
+      session
+      |> assert_has("#last-target", "LD2451")
+      |> assert_has("#last-target", "Test mode")
+      |> assert_has("#last-target", "Radar diagnostic")
+      |> assert_has("#last-target", "Normal")
+      |> unwrap(fn view ->
+        view
+        |> Phoenix.LiveViewTest.element("button[phx-value-device='rd03d']")
+        |> Phoenix.LiveViewTest.render_click()
+      end)
+
+    session
+    |> assert_has("#device-config-selector .btn-primary", "RD03-D")
+    |> assert_has("#last-target", "LD2451")
+    |> assert_has("#last-target", "Test mode")
+    |> assert_has("#last-target", "Radar diagnostic")
+    |> assert_has("#last-target", "Normal")
   end
 
   test "persists radar configuration changes and restores canvas limits after reload", %{


### PR DESCRIPTION
Beadwork: rc-edm.10

Stacked on: #7

Summary:
- Tag target data with the registered uploader device_type and test_mode.
- Show active uploader device and mode in admin debug/status panels.
- Replace hardcoded RD03-D sentinel wording with device-aware diagnostics.
- Keep canvas/debug config tied to the active radar while switching stored config tabs.

Verification:
- mix format --check-formatted
- mix test test/radar_web/channels/radar_config_channel_test.exs test/radar_web/live/admin_live_test.exs
- mix test